### PR TITLE
Fix \AA symbol for MathJax

### DIFF
--- a/cicero/static/js/mathjax-setup.js
+++ b/cicero/static/js/mathjax-setup.js
@@ -1,6 +1,12 @@
 MathJax.Hub.Config({
     tex2jax: {
-    skipTags: ['script', 'noscript', 'style', 'textarea', 'pre']
+      skipTags: ['script', 'noscript', 'style', 'textarea', 'pre']
+    },
+    "TeX": {
+      Macros: {AA : "{\\unicode{x212B}}"}
+    },
+    "HTML-CSS": {
+      scale: 90
     }
 });
 MathJax.Hub.Queue(function() {


### PR DESCRIPTION
A small fix to correctly render the Angstrom symbol with MathJax.