### PR TITLE
Enable `$` symbol as inline math delimiter

### DIFF
--- a/cicero/static/js/mathjax-setup.js
+++ b/cicero/static/js/mathjax-setup.js
@@ -1,6 +1,8 @@
 MathJax.Hub.Config({
     tex2jax: {
-      skipTags: ['script', 'noscript', 'style', 'textarea', 'pre']
+      skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],
+      inlineMath: [['$','$'], ['\\(','\\)']],
+      processEscapes: true
     },
     "TeX": {
       Macros: {AA : "{\\unicode{x212B}}"}


### PR DESCRIPTION
Both `$` and `\\(`, `\\)` can be used as inline math delimiter. This removes the need to use backticks to start an inline math environment, which causes inline symbols to have a grey shading. **WARNING** This might possibly break slide decks with inline math using backticks.
