### PR TITLE
fix reference to homepage in 404.html

### DIFF
--- a/cicero/templates/404.html
+++ b/cicero/templates/404.html
@@ -8,7 +8,7 @@
     <div class="row">
       <h1>Page Not Found</h1>
       What you were looking for is just not there. Go somewhere
-      <a href="{{ url_for('home') }}">nice</a>.
+      <a href="{{ url_for('git.home') }}">nice</a>.
     </div>
   </div>
 </div>


### PR DESCRIPTION
the name of the home page is 'git.home', not 'home'.

fixes bast/cicero#36