### PR TITLE
Workaround for MathJax and Autoload-all

### DIFF
--- a/cicero/static/js/mathjax-setup.js
+++ b/cicero/static/js/mathjax-setup.js
@@ -19,4 +19,11 @@ MathJax.Hub.Queue(function() {
     }).parent().addClass('has-jax');
 });
 
+MathJax.Hub.Register.StartupHook("TeX autoload-all Ready", function () {
+  var MACROS = MathJax.InputJax.TeX.Definitions.macros;
+  MACROS.color = "Color";
+  delete MACROS.colorbox;
+  delete MACROS.fcolorbox;
+});
+
 MathJax.Hub.Configured();


### PR DESCRIPTION
This preserves the original definition of the \color macro as prescribed here:
http://docs.mathjax.org/en/latest/tex.html#autoload-all