### PR TITLE
Support user defined javascript and remark configuration

### DIFF
--- a/cicero/git.py
+++ b/cicero/git.py
@@ -101,6 +101,16 @@ def render_github_markdown(path, engine, engine_version):
             own_javascript = response.read().decode("utf-8")
         except IOError:
             own_javascript = ''
+        # use custom configuration for the rendering engine, if available
+        try:
+            url = prefix + '/' + file_without_suffix + '.conf'
+            response = _urlopen(url)
+            own_conf = ''
+            for line in response.readlines():
+                own_conf += line.decode("utf-8").replace('\n', ',\n')
+            own_conf = own_conf.rstrip('\n')
+        except IOError:
+            own_conf = ''
 
         return flask.render_template('render.html',
                                      title=title,
@@ -108,6 +118,7 @@ def render_github_markdown(path, engine, engine_version):
                                      style=style,
                                      own_css=own_css,
                                      own_javascript=own_javascript,
+                                     own_conf=own_conf,
                                      engine='{0}-{1}'.format(engine, engine_version))
     except IOError:
         return flask.render_template('404.html')

--- a/cicero/git.py
+++ b/cicero/git.py
@@ -84,22 +84,30 @@ def render_github_markdown(path, engine, engine_version):
         if style is None:
             style = 'default'
 
+        file_without_suffix, _suffix = os.path.splitext(last_file)
         # if own css is available, we load it
         # if not, we default to empty own css
         try:
-            file_without_suffix, _suffix = os.path.splitext(last_file)
             url = prefix + '/' + file_without_suffix + '.css'
             response = _urlopen(url)
             own_css = response.read().decode("utf-8")
         except IOError:
             own_css = ''
         own_css = flask.Markup(own_css) # disable autoescaping
+        # .. do the same for own javascript
+        try:
+            url = prefix + '/' + file_without_suffix + '.js'
+            response = _urlopen(url)
+            own_javascript = response.read().decode("utf-8")
+        except IOError:
+            own_javascript = ''
 
         return flask.render_template('render.html',
                                      title=title,
                                      markdown=fix_images(markdown, prefix),
                                      style=style,
                                      own_css=own_css,
+                                     own_javascript=own_javascript,
                                      engine='{0}-{1}'.format(engine, engine_version))
     except IOError:
         return flask.render_template('404.html')

--- a/cicero/git.py
+++ b/cicero/git.py
@@ -93,6 +93,7 @@ def render_github_markdown(path, engine, engine_version):
             own_css = response.read().decode("utf-8")
         except IOError:
             own_css = ''
+        own_css = flask.Markup(own_css) # disable autoescaping
 
         return flask.render_template('render.html',
                                      title=title,

--- a/cicero/preview.py
+++ b/cicero/preview.py
@@ -36,6 +36,14 @@ def home():
     if os.path.isfile(own_js_file):
         with io.open(own_js_file, 'r') as js_file:
             own_javascript = js_file.read()
+    # use custom configuration for the rendering engine, if available
+    own_conf_file = talk_no_suffix + '.conf'
+    own_conf = ''
+    if os.path.isfile(own_conf_file):
+        with io.open(own_conf_file, 'r') as conf_file:
+            for line in conf_file.readlines():
+                own_conf += line.replace('\n', ',\n')
+            own_conf = own_conf.rstrip('\n')
 
     return render_template('render.html',
                            title=title,
@@ -43,6 +51,7 @@ def home():
                            style=style,
                            own_css=own_css,
                            own_javascript=own_javascript,
+                           own_conf=own_conf,
                            engine=config['engine'])
 
 

--- a/cicero/preview.py
+++ b/cicero/preview.py
@@ -7,7 +7,7 @@ blueprint = Blueprint('preview', __name__)
 def home():
     import io
     import os
-    from flask import current_app, render_template, render_template_string, request
+    from flask import current_app, render_template, render_template_string, request, Markup
     from .title import extract_title
     from .images import fix_images
 
@@ -29,6 +29,7 @@ def home():
     if os.path.isfile(own_css_file):
         with io.open(own_css_file, 'r') as css_file:
             own_css = css_file.read()
+    own_css = Markup(own_css) # disable autoescaping
 
     return render_template('render.html',
                            title=title,

--- a/cicero/preview.py
+++ b/cicero/preview.py
@@ -30,12 +30,19 @@ def home():
         with io.open(own_css_file, 'r') as css_file:
             own_css = css_file.read()
     own_css = Markup(own_css) # disable autoescaping
+    # use own javascript, if available
+    own_js_file = talk_no_suffix + '.js'
+    own_javascript = ''
+    if os.path.isfile(own_js_file):
+        with io.open(own_js_file, 'r') as js_file:
+            own_javascript = js_file.read()
 
     return render_template('render.html',
                            title=title,
                            markdown=markdown,
                            style=style,
                            own_css=own_css,
+                           own_javascript=own_javascript,
                            engine=config['engine'])
 
 

--- a/cicero/static/engines/remark-0.13.0/js.html
+++ b/cicero/static/engines/remark-0.13.0/js.html
@@ -1,4 +1,5 @@
 <script type="text/javascript">
+    {{ own_javascript|indent|safe }}
     var slideshow = remark.create({
         highlightStyle: '{{ style }}',
         highlightLines: true

--- a/cicero/static/engines/remark-0.13.0/js.html
+++ b/cicero/static/engines/remark-0.13.0/js.html
@@ -1,6 +1,7 @@
 <script type="text/javascript">
     {{ own_javascript|indent|safe }}
     var slideshow = remark.create({
+        {{ own_conf|indent(8)|safe }}
         highlightStyle: '{{ style }}',
         highlightLines: true
       }) ;


### PR DESCRIPTION
Added support for custom remark configuration options and for adding user defined javascript before `remark.create()` is called, e.g. to add custom remark macros.

Used similar approach as with user defined CSS, so javascript / configuration options are read from files with the same base as the markdown content:
- talk.md
- talk.css
- talk.js (new file for javascript)
- talk.config (new file for configuration options)

In addition, to fix mangling of e.g. quotation marks in user defined CSS, added `Markup()` to disable autoescaping of the CSS file content.