### PR TITLE
Default host

### DIFF
--- a/cicero/cli.py
+++ b/cicero/cli.py
@@ -9,7 +9,7 @@ def parse_args():
     arg('--file', '-f', dest='filename', help='serve a local file')
     arg('--engine', dest='engine', help='rendering engine', default='remark-0.13.0')
     arg('--debug', dest='debug', action='store_true', default=False)
-    arg('--host', dest='host', default=os.environ.get('HOST', '0.0.0.0'))
+    arg('--host', dest='host', default=os.environ.get('HOST', '127.0.0.1'))
     arg('--port', dest='port', type=int, default=int(os.environ.get('PORT', 5000)))
 
     return parser.parse_args()

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,18 @@
 
 from distutils.core import setup
 
+import os
+
+def package_files(directory):
+    paths = []
+    for (path, directories, filenames) in os.walk(directory, followlinks=True):
+        for filename in filenames:
+            paths.append(os.path.join('..', path, filename))
+    return paths
+
+extra_files = package_files('cicero/static') + \
+              package_files('cicero/templates')
+
 setup(name='cicero',
       version='0.1.0',
       description='Cicero - Serving slides written in Markdown.',
@@ -9,6 +21,7 @@ setup(name='cicero',
       author_email='bast@users.noreply.github.com',
       url='https://github.com/bast/cicero',
       packages=['cicero'],
+      package_data={'': extra_files},
       license='GNU Lesser General Public License 2.1',
       entry_points={
             'console_scripts': [


### PR DESCRIPTION
If you bind to 0.0.0.0 OS X firewall will ask for admin permissions to listen to everything. If you bind to 127.0.0.1 by default it won't.