### PR TITLE
Extract title from .title[my title]

### DIFF
--- a/cicero/title.py
+++ b/cicero/title.py
@@ -2,7 +2,7 @@ def extract_title(markdown):
     for line in markdown.split('\n'):
         if ".title[" in line:
             start = line.index(".title[") + len(".title[")
-            end = line.rindex( "]", start)
+            end = line.rindex("]", start)
             return line[start:end]
         if '#' in line:
             index_first_non_whitespace = len(line) - len(line.lstrip())

--- a/cicero/title.py
+++ b/cicero/title.py
@@ -1,5 +1,9 @@
 def extract_title(markdown):
     for line in markdown.split('\n'):
+        if ".title[" in line:
+            start = line.index(".title[") + len(".title[")
+            end = line.rindex( "]", start)
+            return line[start:end]
         if '#' in line:
             index_first_non_whitespace = len(line) - len(line.lstrip())
             index_first_hash = line.index('#')
@@ -29,4 +33,22 @@ def test_extract_title():
     Code examples: [OSI](http://opensource.org)-approved [MIT license](http://opensource.org/licenses/mit-license.html).
 
     ---'''
+    markdown_alt = '''name: inverse
+    layout: true
+    class: center, middle, inverse
+
+    ---
+
+    .title[Talking to [C/C++/Fortran] via CFFI]
+
+    .author[Radovan Bast]
+
+    High Performance Computing Group,
+    UiT The Arctic University of Norway
+
+    Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+    Code examples: [OSI](http://opensource.org)-approved [MIT license](http://opensource.org/licenses/mit-license.html).
+
+    ---'''
     assert extract_title(markdown) == 'Talking to C/C++/Fortran via CFFI'
+    assert extract_title(markdown_alt) == 'Talking to [C/C++/Fortran] via CFFI'


### PR DESCRIPTION
Previously the HTML title was extracted from the first
occurrence of #. Thus, the HTML title was the title of
my second slide if I used .title for the first slide.

Please modify this pull request as you like:)
